### PR TITLE
Adding index.js file as indexTs.ts file

### DIFF
--- a/src/indexTs.ts
+++ b/src/indexTs.ts
@@ -1,0 +1,46 @@
+import {Logger} from 'aurelia-logging';
+
+/*
+ * An implementation of the Appender interface.
+ */
+export class ConsoleAppender {
+    /**
+    * Appends a debug log.
+    *
+    * @param logger The source logger.
+    * @param rest The data to log.
+    */
+    debug(logger: Logger, ...rest: any[]): void {
+        console.debug(`DEBUG [${logger.id}]`, ...rest);
+    }
+
+    /**
+    * Appends an info log.
+    *
+    * @param logger The source logger.
+    * @param rest The data to log.
+    */
+    info(logger: Logger, ...rest: any[]): void {
+        console.info(`INFO [${logger.id}]`, ...rest);
+    }
+
+    /**
+    * Appends a warning log.
+    *
+    * @param logger The source logger.
+    * @param rest The data to log.
+    */
+    warn(logger: Logger, ...rest: any[]): void {
+        console.warn(`WARN [${logger.id}]`, ...rest);
+    }
+
+    /**
+    * Appends an error log.
+    *
+    * @param logger The source logger.
+    * @param rest The data to log.
+    */
+    error(logger: Logger, ...rest: any[]): void {
+        console.error(`ERROR [${logger.id}]`, ...rest);
+    }
+}


### PR DESCRIPTION
I have try to use this logger as index.js file ( https://stackoverflow.com/questions/37791068/send-aurelia-error-logs-to-server-and-notify-the-user/37791288#comment69067093_37791288 ), but my IDE (Visual Studio 2015 Update3) had errors and don't seen that file.
I switched extension to .ts file, and it worked for me (compiller generated .js file from .ts file and everything starts working).

Propably issue is in tsconfig.json -> "target": "es5", but I will put this file here for other people that have might same problem.